### PR TITLE
android-tool-path Windows Compatibility

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -63,7 +63,7 @@
 (defun android-tool-path (name)
   "Find path to SDK tool."
   (or (find-if #'file-exists-p
-               (apply #'vconcat
+               (apply #'append
                       (mapcar (lambda (path)
                                 (mapcar (lambda (ext)
                                           (mapconcat 'identity
@@ -72,16 +72,6 @@
                                                      "/"))
                                         android-mode-sdk-tool-extensions))
                               android-mode-sdk-tool-subdirs)))
-      (error "can't find SDK tool: %s" name)))
-
-(defun android-tool-path (name)
-  "Find path to SDK tool."
-  (or (find-if #'file-exists-p
-               (mapcar (lambda (path)
-                         (mapconcat 'identity
-                                    `(,android-mode-sdk-dir ,path ,name)
-                                    "/"))
-                       android-mode-sdk-tool-subdirs))
       (error "can't find SDK tool: %s" name)))
 
 (defun android-list-avd ()


### PR DESCRIPTION
Thanks for the void-function fix!

I do most of my Android dev on Windows and android-tool-path doesn't work properly 'cause most of Android tools have extensions on Windows.

I've updated android-tool-path to iterate through a predefined list of possible extensions ("", ".bat", ".exe" right now) to find a hit.

I've verified this works on Windows & Linux.

Take a look and let me know if you have any questions.

Thanks,
Cristian
