### PR TITLE
Symbol's function definition is void: android-mode-local-sdk-dir

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -90,7 +90,7 @@ defined sdk directory. Defaults to `android-mode-sdk-dir'."
                       (mapcar (lambda (path)
                                 (mapcar (lambda (ext)
                                           (mapconcat 'identity
-                                                     `(,(android-mode-local-sdk-dir)
+                                                     `(,(android-local-sdk-dir)
                                                        ,path ,(concat name ext))
                                                      "/"))
                                         android-mode-sdk-tool-extensions))


### PR DESCRIPTION
https://github.com/remvee/android-mode/blob/master/android-mode.el#L93 incorrectly calls android-local-sdk-dir as android-mode-local-sdk-dir.
