### PR TITLE
New functions in android-mode

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -389,7 +389,6 @@ The function grabs the first activity name as a first approximation."
     ("i" . android-ant-installd)
     ("r" . android-ant-reinstall)
     ("u" . android-ant-uninstall)
-    ("N" . android-create-project)
     ("a" . android-start-app)))
 
 (defvar android-mode-map (make-sparse-keymap))


### PR DESCRIPTION
I recently got back into android development in emacs and created a few functions that I was missing:
- `android-create-project`
  
  Asks for all the required fields then opens the new project directory
- `android-list-targets`
  
  Used by `android-create-project` to list all the targets you have installed
- `android-start-app`
  
  Start your app from emacs. I also had this bound to `C-c C-c a`.

I also fixed ant targets that changed in the latest SDK releases.
