### PR TITLE
Enhance the algorithm which finds launcher activity's name.

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -327,7 +327,7 @@ defined sdk directory. Defaults to `android-mode-sdk-dir'."
 (defun android-launcher-activity ()
   "Return the main launcher activity class name.
 
-The function grabs the first activity name as a first approximation."
+The function grabs the first activity name."
   (interactive)
   (android-in-root
    (let ((manifest "AndroidManifest.xml")
@@ -338,7 +338,9 @@ The function grabs the first activity name as a first approximation."
               (erase-buffer)
               (insert-file-contents manifest)
               (goto-char (point-min))
-              (and (re-search-forward "android:name=\"\\(.*?\\)\"" nil t)
+              (and (goto-char (search-forward "android.intent.category.LAUNCHER"))
+                   (goto-char (search-backward "<activity"))
+                   (re-search-forward "android:name[ ]*=[ ]*\"\\(.*?\\)\"" nil t)
                    (let ((activity-name (match-string 1)))
                      (kill-buffer buffer)
                      activity-name))))))))


### PR DESCRIPTION
Original launcher finding algorithm was too naive. If launcher activity is written at the bottom of AndroidManifest.xml, original algorithm can't find right launcher activity.

According to android documentation(http://developer.android.com/reference/android/content/Intent.html), activity should include intent-filter tag like below to make the activity into a launcher activity.

``` xml
<activity class="StartActivity" android:label="@string/title">
  <intent-filter>
    <action android:name="android.intent.action.MAIN" />
    <category android:name="android.intent.category.LAUNCHER" />
  </intent-filter>
</activity>
```

I enhance the algorithm using the fact that a launch activity tag should include intent-filter and category tag whose name is "android.intent.category.LAUNCHER".
