### PR TITLE
Make ant use emacs option for compilation-mode.

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -360,7 +360,7 @@ The function grabs the first activity name."
   "Run ant TASK in the project root directory."
   (interactive "sTask: ")
   (android-in-root
-   (compile (concat "ant " task))))
+   (compile (concat "ant -e " task))))
 
 (defmacro android-defun-ant-task (task)
   `(defun ,(intern (concat "android-ant-"


### PR DESCRIPTION
Without this patch, link detection was wrong in a compilation buffer.

So we couldn't use powerful shortcuts like "M-g M-n" or "M-g M-p".

If we use a "-emacs" option of ant, we can easily deal with this problem.

This option makes output more readable for emacs.

With this option, compilation-mode can detect links correctly.
