### PR TITLE
Logcat has compilation-minor-mode

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -310,6 +310,24 @@ defined sdk directory. Defaults to `android-mode-sdk-dir'."
     ("^\\(W\\)\s\\(.+([0-9]+)\\)\\(\t\\|\s\\)+\\(.+\\)$" 4 nil nil 1 nil (4 'android-mode-warning-face))
     ("^\\(E\\)\s\\(.+([0-9]+)\\)\\(\t\\|\s\\)+\\(.+\\)$" 4 nil nil 2 nil (4 'android-mode-error-face))))
 
+(defun android-logcat-browse-url (n &optional reset)
+  "This modfied next-error-internal provides web search stuff using browse-url
+with compilation-next-error--message as a keyword. This is pretty good enough to
+know about a next-error, although it's implement is dirty and not in compilation-minor-mode's general way."
+  (let ((logcat-next-error-message nil)
+        (logcat-search-query nil ))
+    (setq logcat-next-error-message
+          (caar (elt (elt (substring
+                           (compilation-next-error (or 0 1) nil
+                                                   (or compilation-current-error
+                                                       compilation-messages-start
+                                                       (point-min))) 1 2) 0) 2)))
+    (setq logcat-search-query
+          (read-from-minibuffer "Web Search Keywords: " logcat-next-error-message))
+    (if (= (length logcat-search-query) 0)
+        (message "Quit")
+      (browse-url (format android-mode-search-query-format logcat-search-query)))))
+
 (defun android-logcat ()
   "Switch to ADB logcat buffer, create it when it doesn't exists yet."
   (interactive)
@@ -324,28 +342,9 @@ defined sdk directory. Defaults to `android-mode-sdk-dir'."
       (use-local-map android-logcat-map)
       (set (make-local-variable 'compilation-message-face) '((t (:underline nil))))
       (set (make-local-variable 'compilation-error-regexp-alist) android-logcat-compilation-error-regexp-alist)
-      ;; This is pretty good enough to know about a next-error,
-      ;; although it's implement is dirty and not in compilation-minor-mode's general way.
-      ;; This modfied next-error-internal provides web search stuff using browse-url function
-      ;; with compilation-next-error--message as a keyword.
-      (defadvice next-error-internal (around around-next-error-internal)
-        (setq next-error-last-buffer (current-buffer))
-        (with-current-buffer next-error-last-buffer
-          (let ((logcat-next-error-message nil)
-                (logcat-search-query nil ))
-            (setq logcat-next-error-message
-                  (caar (elt (elt (substring
-                                   (compilation-next-error (or 0 1) nil
-                                                           (or compilation-current-error
-                                                               compilation-messages-start
-                                                               (point-min))) 1 2) 0) 2)))
-            (setq logcat-search-query
-                  (read-from-minibuffer "Web Search Keywords: " logcat-next-error-message))
-            (if (= (length logcat-search-query) 0)
-                (message "Quit")
-              (browse-url (format android-mode-search-query-format logcat-search-query))))))
-      (ad-activate 'next-error-internal)
       (compilation-minor-mode)
+      (set (make-local-variable 'next-error-function)
+           'android-logcat-browse-url)
       (font-lock-mode t)
       (android-mode t)))
   (switch-to-buffer android-logcat-buffer)


### PR DESCRIPTION
This fix include:
- useful key bindings: M-p / M-n / RET and many others that provided by compilation-minor-mode
- user can search error log in easy way: RET or C-c C-c
