### PR TITLE
Add support for ant 'test' targets and a corresponding key-binding

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -405,6 +405,7 @@ activity in the 'launcher' category."
      (android-ant ,task)))
 
 (android-defun-ant-task "clean")
+(android-defun-ant-task "test")
 (android-defun-ant-task "debug")
 (android-defun-ant-task "installd")
 (android-defun-ant-task "uninstall")
@@ -414,6 +415,7 @@ activity in the 'launcher' category."
     ("e" . android-start-emulator)
     ("l" . android-logcat)
     ("C" . android-ant-clean)
+    ("t" . android-ant-test)
     ("c" . android-ant-debug)
     ("i" . android-ant-installd)
     ("r" . android-ant-reinstall)


### PR DESCRIPTION
I added a key-binding for the common 'test' target in Android test projects.  Would you consider merging it so it will eventually end up in the package repos?

Best,

k 

Signed-off-by: Karsten Gebbert karsten@null2.net
