### PR TITLE
Add support for Maven

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -464,36 +464,36 @@ activity in the 'launcher' category."
   "Run the tests."
   (interactive)
   (funcall (case android-mode-builder
-                  ('ant 'android-ant-test)
-                  ('maven 'android-maven-test))))
+             ('ant 'android-ant-test)
+             ('maven 'android-maven-test))))
 
 (defun android-build-debug ()
   "Build the application in a debug mode."
   (interactive)
   (funcall (case android-mode-builder
-                  ('ant 'android-ant-debug)
-                  ('maven 'android-maven-install))))
+             ('ant 'android-ant-debug)
+             ('maven 'android-maven-install))))
 
 (defun android-build-install ()
   "Install a generated apk file to the device."
   (interactive)
   (funcall (case android-mode-builder
-                  ('ant 'android-ant-installd)
-                  ('maven 'android-maven-android-deploy))))
+             ('ant 'android-ant-installd)
+             ('maven 'android-maven-android-deploy))))
 
 (defun android-build-reinstall ()
   "Reinstall a generated apk file to the device."
   (interactive)
   (funcall (case android-mode-builder
-                  ('ant 'android-ant-reinstall)
-                  ('maven 'android-maven-android-redeploy))))
+             ('ant 'android-ant-reinstall)
+             ('maven 'android-maven-android-redeploy))))
 
 (defun android-build-uninstall ()
   "Uninstall a generated apk file from the device."
   (interactive)
   (funcall (case android-mode-builder
-                  ('ant 'android-ant-uninstall)
-                  ('maven 'android-maven-android-undeploy))))
+             ('ant 'android-ant-uninstall)
+             ('maven 'android-maven-android-undeploy))))
 
 (defconst android-mode-keys
   '(("d" . android-start-ddms)


### PR DESCRIPTION
In the android world, there are several method to build such as ant, maven, gradle.

Especially, [maven-android-plugin](https://github.com/jayway/maven-android-plugin) is commonly used to build an android project with maven.

This is a pull request for supporting maven and I use names of goals which is used in maven-android-plugin.
