### PR TITLE
Add support for the gradle build system

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -539,7 +539,7 @@ logs"
   (interactive)
   (funcall (case android-mode-builder
              ('ant 'android-ant-clean)
-             ('gradle 'anddroid-gradle-clean)
+             ('gradle 'android-gradle-clean)
              ('maven 'android-maven-clean))))
 
 (defun android-build-test ()


### PR DESCRIPTION
I also fixed the way the android-mode-builder custom variable worked.  It previously broke things when customized.
