### PR TITLE
If set, use the ANDROID_HOME environment variable for android-mode-sdk-dir.

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -53,7 +53,8 @@
   :prefix "android-mode-"
   :group 'applications)
 
-(defcustom android-mode-sdk-dir "~/Android/sdk"
+(defcustom android-mode-sdk-dir
+  (or (getenv "ANDROID_HOME") "~/Android/sdk")
   "Set to the directory containing the Android SDK."
   :type 'string
   :group 'android-mode)


### PR DESCRIPTION
No reason to set this in more than one place if you don't have to.
