### PR TITLE
BUGFIX: raise error in android-in-root will fail android-local-sdk-dir

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -363,7 +363,7 @@ environment value otherwise the `android-mode-sdk-dir' variable."
   (interactive)
   (when (android-start-exclusive-command android-logcat-buffer
                                          (android-tool-path "adb")
-                                         "logcat")
+                                         "logcat -v brief")
     (set-process-filter (get-buffer-process android-logcat-buffer)
                         #'android-logcat-process-filter)
     (with-current-buffer android-logcat-buffer

--- a/android-mode.el
+++ b/android-mode.el
@@ -1,4 +1,4 @@
-;;; android-mode.el --- Minor mode for Android application development
+x;;; android-mode.el --- Minor mode for Android application development
 
 ;; Copyright (C) 2009-2014 R.W van 't Veer
 
@@ -165,7 +165,7 @@ root directory can be found."
      (if android-root-dir
        (let ((default-directory android-root-dir))
          ,body)
-       (error "can't find project root"))))
+       )))
 
 (defun android-local-sdk-dir ()
   "Try to find android sdk directory through the local.properties


### PR DESCRIPTION
when you do not have a local sdk. Raise error will cause android-logcat failed 
