### PR TITLE
changed android-mode-builder to gradle and plist to gradlew

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -74,7 +74,7 @@ available."
   :type '(repeat string)
   :group 'android-mode)
 
-(defcustom android-mode-builder 'ant
+(defcustom android-mode-builder 'gradle
   "Builder for building an android application.
 When customizing `android-mode-builder' it's important to make
 sure that a corresponding entry exists in
@@ -85,7 +85,7 @@ sure that a corresponding entry exists in
 
 (defcustom android-mode-root-file-plist '(ant "AndroidManifest.xml"
                                           maven  "AndroidManifest.xml"
-                                          gradle "build.gradle")
+                                          gradle "gradlew")
   "Plist of mapping between different builders and the file that
   signifies the root of a project that uses that builder."
   :type '(plist :key-type symbol


### PR DESCRIPTION
per issue #50 and @wizmer's suggestion, I changed the default builder to `gradle` and fixed the root directory for gradle from `build.gradle` to `gradlew`.

I'd like to help further with this project so that maybe `android-create-project` works as intended but here's a quick PR for now.