### PR TITLE
Properly quote shell commands and arguments

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -204,7 +204,9 @@ environment value otherwise the `android-mode-sdk-dir' variable."
 (defvar android-exclusive-processes ())
 (defun android-start-exclusive-command (name command &rest args)
   (and (not (cl-find (intern name) android-exclusive-processes))
-       (set-process-sentinel (apply 'start-process-shell-command name name command args)
+       (set-process-sentinel (apply #'start-process-shell-command name name
+                                    (shell-quote-argument command)
+                                    (mapcar #'shell-quote-argument args))
                              (lambda (proc msg)
                                (when (memq (process-status proc) '(exit signal))
                                  (setq android-exclusive-processes


### PR DESCRIPTION
Fixes issues when whitespace is used in commands/arguments. On Windows:

```
$ echo $ANDROID_HOME
c:/Program Files (x86)/Android/android-sdk/
```

results in (german locale 😢 ):

```
Der Befehl "c:/Program" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.

```