### PR TITLE
Starting app fails for Gradle projects

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -1,6 +1,6 @@
 ;;; android-mode.el --- Minor mode for Android application development
 
-;; Copyright (C) 2009-2014 R.W van 't Veer
+;; Copyright (C) 2009-2018 R.W van 't Veer
 
 ;; Author: R.W. van 't Veer
 ;; Created: 20 Feb 2009
@@ -20,6 +20,7 @@
 ;;   K. Adam Christensen
 ;;   Haden Pike
 ;;   Camilo QS
+;;   Jonathan Schmeling
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -166,25 +167,32 @@ If received line from logcat doesn't match this, Emacs will
 ignore that line.  User can see their log in a less verbose
 way.")
 
-(defun android-root ()
-  "Look for AndroidManifest.xml file to find project root of android application."
-  (let ((dominating-file (plist-get android-mode-root-file-plist
-                                    android-mode-builder)))
-    (if dominating-file
-        (locate-dominating-file default-directory dominating-file)
-      (message "%s was not found in `android-mode-root-file-plist'"
-               android-mode-builder)
-      nil)))
+(defun android-find-dir (filename)
+  "Look for specified file to find the directory in which the file is located."
+  (if filename
+      (locate-dominating-file default-directory filename)
+    (message "%s was not found in `android-mode-root-file-plist'"
+             android-mode-builder)
+    nil))
 
-(defmacro android-in-root (body)
-  "Execute BODY form with project root directory as
+(defun android-root ()
+  "Look for the builder's main file (AndroidManifest.xml for ant and maven,
+ gradlew for gradle) to find project root of android application."
+  (android-find-dir (plist-get android-mode-root-file-plist
+                               android-mode-builder)))
+
+(defun android-manifest ()
+  "Look for AndroidManifest.xml to find the directory it's located in."
+  (android-find-dir "AndroidManifest.xml"))
+
+(defmacro android-in-directory (chosen-dir body)
+  "Execute BODY form with chosen root directory as
 ``default-directory''.  The form is not executed when no project
 root directory can be found."
-  `(let ((android-root-dir (android-root)))
-     (if android-root-dir
-       (let ((default-directory android-root-dir))
+  `(if ,chosen-dir
+       (let ((default-directory ,chosen-dir))
          ,body)
-       (error "can't find project root"))))
+     (error "can't find project root")))
 
 (defun android-local-sdk-dir ()
   "Try to find android sdk directory through the local.properties
@@ -194,7 +202,8 @@ referred directory does not exist, return the ANDROID_HOME
 environment value otherwise the `android-mode-sdk-dir' variable."
   (or
    (ignore-errors
-     (android-in-root
+     (android-in-directory
+      (android-root)
       (let ((local-properties "local.properties"))
         (and (file-exists-p local-properties)
              (with-temp-buffer
@@ -420,7 +429,8 @@ current buffer."
 
 (defun android-project-package ()
   "Return the package of the Android project"
-  (android-in-root
+  (android-in-directory
+   (android-manifest)
    (let ((root (car (xml-parse-file "AndroidManifest.xml"))))
      (xml-get-attribute root 'package))))
 
@@ -431,7 +441,8 @@ Names starting with a period or a capital letter are prepended by
 the project package name.
 
 Filter on CATEGORY intent when supplied."
-  (android-in-root
+  (android-in-directory
+   (android-manifest)
    (cl-flet* ((first-xml-child (parent name)
                                (car (xml-get-children parent name)))
               (action-main-p (activity)
@@ -515,7 +526,8 @@ logs"
   `(defun ,(intern (concat "android-" builder)) (tasks-or-goals)
      ,(concat "Run " builder " TASKS-OR-GOALS in the project root directory.")
      (interactive "sTasks or Goals: ")
-     (android-in-root
+     (android-in-directory
+      (android-root)
       (compile (concat (cdr (assoc (intern ,builder) android-mode-build-command-alist))
                        " " tasks-or-goals)))))
 

--- a/android-mode.el
+++ b/android-mode.el
@@ -181,7 +181,7 @@ way.")
   (android-find-dir (plist-get android-mode-root-file-plist
                                android-mode-builder)))
 
-(defun android-manifest ()
+(defun android-manifest-dir ()
   "Look for AndroidManifest.xml to find the directory it's located in."
   (android-find-dir "AndroidManifest.xml"))
 
@@ -430,7 +430,7 @@ current buffer."
 (defun android-project-package ()
   "Return the package of the Android project"
   (android-in-directory
-   (android-manifest)
+   (android-manifest-dir)
    (let ((root (car (xml-parse-file "AndroidManifest.xml"))))
      (xml-get-attribute root 'package))))
 
@@ -442,7 +442,7 @@ the project package name.
 
 Filter on CATEGORY intent when supplied."
   (android-in-directory
-   (android-manifest)
+   (android-manifest-dir)
    (cl-flet* ((first-xml-child (parent name)
                                (car (xml-get-children parent name)))
               (action-main-p (activity)


### PR DESCRIPTION
Assuming the AndroidManifest.xml file has always been in its current place, this was always an issue but, perhaps, a more pressing one, now, since users are forced to use Android Studio to generate a new project layout since Google removed the ability to do so through the command-line and Android Studio uses gradle.

Since, for gradle projects, AndroidManifest.xml is not located in the project root but being able to get the project root is probably still a useful ability, keep the `android-root` function and add a `android-manifest` function to, specifically, search for the directory containing the AndroidManifest.xml file. Since the code is almost entire similar, also create a helper function by the name of `android-find-dir`.

Since some of the functions were using `android-in-root` on the assumption that that's where the AndroidManifest.xml was located, adjust `android-in-root` to allow the user to choose the location that
`default-directory` should be set to and adjust the name to one that makes more sense, given the change.

Lastly, update the locations that were `android-in-root` to `android-in-directory` and operate in `(android-root)` or `(android-manifest)` depending on the need of the function (in truth, I just changed the ones to `android-manifest` that I knew needed it and kept the others in `android-root` since that's how it was, before; I didn't really test if the functions I didn't run into an issue with had the same issue).