### PR TITLE
[[Bug]] `android-start-emulator` Doesn't Start Emulator

### DIFF
--- a/android-mode.el
+++ b/android-mode.el
@@ -235,8 +235,11 @@ environment value otherwise the `android-mode-sdk-dir' variable."
   "Run COMMAND named NAME with ARGS unless it's already running."
   (and (not (cl-find (intern name) android-exclusive-processes))
        (set-process-sentinel (apply #'start-process-shell-command name name
-                                    command
-                                    (mapcar #'shell-quote-argument args))
+                                    (concat command
+                                            " "
+                                            (mapconcat #'shell-quote-argument
+                                                       args
+                                                       " ")))
                              (lambda (proc msg)
                                (when (memq (process-status proc) '(exit signal))
                                  (setq android-exclusive-processes

--- a/android-mode.el
+++ b/android-mode.el
@@ -235,7 +235,7 @@ environment value otherwise the `android-mode-sdk-dir' variable."
   "Run COMMAND named NAME with ARGS unless it's already running."
   (and (not (cl-find (intern name) android-exclusive-processes))
        (set-process-sentinel (apply #'start-process-shell-command name name
-                                    (shell-quote-argument command)
+                                    command
                                     (mapcar #'shell-quote-argument args))
                              (lambda (proc msg)
                                (when (memq (process-status proc) '(exit signal))

--- a/android-mode.el
+++ b/android-mode.el
@@ -295,7 +295,9 @@ environment value otherwise the `android-mode-sdk-dir' variable."
   (let ((avd (or (and (not (string= android-mode-avd "")) android-mode-avd)
                  (completing-read "Android Virtual Device: " (android-list-avd)))))
     (unless (android-start-exclusive-command (concat "*android-emulator-" avd "*")
-                                             (concat (android-tool-path "emulator") " -avd " avd))
+                                             (android-tool-path "emulator")
+                                             "-avd"
+                                             avd)
       (message (concat "emulator " avd " already running")))))
 
 (defun android-start-ddms ()


### PR DESCRIPTION
I noticed that, when calling `C-c a e`, the emulator would just never start, even after I provided an Emulator name.

I eventually traced it back to `android-start-exclusive-command` and the usage of `shell-quote-argument` on `command`. Removing that call from `command` seemed to fix things. I don't understand why this would wreck things and I'm not using a non-standard shell (just the usual bash that comes with Linux (Ubuntu, technically Linux Mint)) so you may want to double check that this issue occurs outside of my machine or that my fix even works for others.

In any case, I removed that call and also adjusted `command` and `args` to to get `concat`ed together since passing additional parameters to `start-process-shell-command` beyond `command` is strongly discouraged, now.